### PR TITLE
Feature/xlsx deploy

### DIFF
--- a/deploy_timemap/.gitignore
+++ b/deploy_timemap/.gitignore
@@ -1,1 +1,2 @@
 test/
+data/

--- a/deploy_timemap/README.md
+++ b/deploy_timemap/README.md
@@ -2,20 +2,28 @@
 Ansible Playbook for Timemap Deployment
 </h1>
 
-An Ansible playbook for remote deployment of an instance of Timemap in conjunction with a dedicated instance of datasheet-server. Multiple Timemap/Datasheet instances may be deployed to the same server, differentiated by the `application_name` set in `vault.yml` (see configuration steps below).
+An Ansible playbook for remote deployment of an instance of Timemap in conjunction with a dedicated instance of datasheet-server. Multiple Timemap/Datasheet instances may be deployed to the same server, either hosting all sources on a single datasheet-server, or running different instances for each source. Datasheets and Timemaps are linked by their respective `name`s. 
 
 # Overview
 
-The playbook's tasks are broken down into four subsets, which are stored in separate files:
+The playbook's tasks are broken down into four successive stages:
 
-* `prepare.yml` installs the relevant packages on the remote server.
-* `datasheet.yml` configures and builds an instance Datasheet-Server on the remote server and launches it inside a docker container.
-* `timemap.yml` configures and builds an instance of Timemap on the host machine and copies the static files to the remote server.
-* `nginx.yml` configures the reverse proxy on the remote server
+* `prepare` - installs the relevant packages on the remote server.
+* `datasheet` - configures and builds an instance Datasheet-Server on the remote server, copies over any XLSX files, and launches the configured server inside a docker container.
+* `timemap` - configures and builds an instance of Timemap locally, and then copies the static files to the remote server.
+* `nginx.yml` configures the reverse proxy on the remote server to expose both
+    `timemap` and `datasheet` externally.
 
-The subtasks are called in sequence from the `_master.yml` playbook file.
 
-N.B. copies of the configuration files for both Timemap and Datasheet-Server in the `credentials` folder on the remote server.
+To run all stages successfully, use:
+```
+ansible-playbook playbooks/deploy_timemap.yml
+```
+
+To run a single stage, use the `--tag` flag:
+```
+ansible-playbook playbooks/deploy_timemap.yml --tag datasheet
+```
 
 # Configuration
 
@@ -23,7 +31,7 @@ First make sure [Ansible is installed](https://docs.ansible.com/ansible/latest/i
 
 Copy `example.env` to a new `.env` file in the same folder and provide your own host group (a server specified in the `inventories/hosts` file) and the location of the ssh key associated with this server.
 
-Copy `example.vault.yml` to a new `vault.yml` in the same folder. The vault file contains all Timemap/Datasheet specific configuration. See the [Timemap](https://github.com/forensic-architecture/timemap) and [Datasheet-Server](https://github.com/forensic-architecture/datasheet-server) documentation for more infomation.
+Copy `example.vault.yml` to a new `vault.yml` in the same folder. The vault file contains all Timemap/Datasheet specific configuration. See the [Timemap](https://github.com/forensic-architecture/timemap) and [Datasheet-Server](https://github.com/forensic-architecture/datasheet-server) documentation for more infomation. All files that end in 'vault.yml' are ignored from git, so you can keep configuration for multiple applications inside this folder locally, and symlink to 'vault.yml' when deploying one.
 
 Note: the domain name can also be an IP address for example:
 

--- a/deploy_timemap/example.env
+++ b/deploy_timemap/example.env
@@ -1,0 +1,10 @@
+export ANSIBLE_HOST_GROUP='fa_internal'
+export ANSIBLE_SSH_KEY_PATH=Users/forensicarchitecture/.ssh/fa_digital_ocean
+export ANSIBLE_REMOTE_USER='root'
+export ANSIBLE_BECOME=false
+
+# override the defaults below with your own forked repository
+# export DATASHEET_GIT_REPOSITORY='https://github.com/forensic-architecture/datasheet-server'
+# export DATASHEET_GIT_BRANCH='develop'
+# export TIMEMAP_GIT_REPOSITORY='https://github.com/forensic-architecture/timemap'
+# export TIMEMAP_GIT_BRANCH='develop'

--- a/deploy_timemap/playbooks/deploy_timemap.yml
+++ b/deploy_timemap/playbooks/deploy_timemap.yml
@@ -7,18 +7,64 @@
   tasks:
     - import_tasks: ../tasks/prepare.yml
       tags: [prepare]
+
     - import_tasks: ../tasks/datasheet.yml
       tags: [datasheet]
-    - import_tasks: ../tasks/timemap.yml
+
+    - name: ansible host - clean timemap repo state
+      local_action:
+        module: file
+        state: absent
+        path: timemap
       tags: [timemap]
-    - import_tasks: ../tasks/nginx.yml
+
+    - name: ansible host - checkout timemap repo
+      local_action:
+        module: git
+        repo: "{{ lookup('env', 'TIMEMAP_GIT_REPOSITORY') or 'https://github.com/forensic-architecture/timemap' }}"
+        dest: timemap
+        version: "{{ lookup('env', 'TIMEMAP_GIT_BRANCH') or 'develop' }}"
+      tags: [timemap]
+
+    - name: ansible host - yarn install
+      local_action:
+        module: yarn
+        path: timemap
+        state: latest
+      tags: [timemap]
+
+    - include_tasks:
+        file: ../tasks/timemap.yml
+        apply:
+          tags: [timemap]
+      tags: [always]
+      loop: "{{ timemaps }}"
+      loop_control:
+        loop_var: timemap
+
+    - name: ansible host - remove timemap repo
+      local_action:
+        module: file
+        state: absent
+        path: timemap
+      tags: [timemap]
+
+    - include_tasks:
+        file: ../tasks/nginx.yml
+        apply:
+          tags: [nginx]
+      loop: "{{ timemaps }}"
+      loop_control:
+        loop_var: timemap
+      tags: [always]
+
+    - name: enable config
+      file: >
+        dest=/etc/nginx/sites-enabled/default
+        src=/etc/nginx/sites-available/default
+        state=link
       tags: [nginx]
 
     - name: restart nginx
       service: name=nginx state=restarted enabled=yes
       tags: [nginx]
-
-    # NOTE: no certbot automation, HTTPS still needs to be done manually as the
-    # right options need to be selected. probably easy to fix.
-    # - name: run certbot
-    #   bash: sudo certbot --nginx -d {{ domain_name }}

--- a/deploy_timemap/playbooks/deploy_timemap.yml
+++ b/deploy_timemap/playbooks/deploy_timemap.yml
@@ -6,12 +6,17 @@
     - ../vars/vault.yml
   tasks:
     - import_tasks: ../tasks/prepare.yml
+      tags: [prepare]
     - import_tasks: ../tasks/datasheet.yml
+      tags: [datasheet]
     - import_tasks: ../tasks/timemap.yml
+      tags: [timemap]
     - import_tasks: ../tasks/nginx.yml
+      tags: [nginx]
 
     - name: restart nginx
       service: name=nginx state=restarted enabled=yes
+      tags: [nginx]
 
     # NOTE: no certbot automation, HTTPS still needs to be done manually as the
     # right options need to be selected. probably easy to fix.

--- a/deploy_timemap/playbooks/generate_templates.yml
+++ b/deploy_timemap/playbooks/generate_templates.yml
@@ -1,9 +1,9 @@
 - hosts: 127.0.0.1
   vars_files:
-    - ./vars/main.yml
-    - ./vars/vault.yml
+    - ../vars/main.yml
+    - ../vars/vault.yml
   tasks:
   - name: Test jinja2template
-    template: src=templates/datasheet_sheets_config.js.j2 dest=test/datasheet_sheets_config.js
+    template: src=../templates/datasheet_sheets_config.js.j2 dest=../datasheet_sheets_config.js
   - name: Test jinja2template
-    template: src=templates/timemap_config.js.j2 dest=test/timemap_config.js
+    template: src=../templates/timemap_config.js.j2 dest=../timemap_config.js

--- a/deploy_timemap/tasks/datasheet.yml
+++ b/deploy_timemap/tasks/datasheet.yml
@@ -16,45 +16,61 @@
     state: directory
 
 - name: copy .env to credentials folder
-  template: src=../templates/datasheet-env.j2 dest=credentials/{{application_name}}.env
+  template: src=../templates/datasheet-env.j2 dest=credentials/{{timemap.name}}.env
 
 - name: copy sheets_config.js to credentials folder
   template: >
     src=../templates/datasheet_sheets_config.js.j2
-    dest=credentials/{{ application_name }}_sheets_config.js
+    dest=credentials/{{ timemap.name }}_sheets_config.js
+
+- name: create XLSX folder if it does not already exist
+  file:
+    path: xlsx
+    state: directory
+
+- name: copy XLSX files to credentials folder
+  copy:
+    src: "{{ item.path }}"
+    dest: xlsx/{{ item.name }}.xlsx
+  loop: "{{ datasheet.xlsx }}"
 
 - name: copy .env to datasheet folder
   copy:
     remote_src: true
-    src: credentials/{{ application_name }}.env
+    src: credentials/{{ timemap.name }}.env
     dest: datasheet-server/.env
 
 - name: copy sheets_config.js to datasheet folder
   copy:
     remote_src: true
-    src: credentials/{{ application_name }}_sheets_config.js
+    src: credentials/{{ timemap.name }}_sheets_config.js
     dest: datasheet-server/src/sheets_config.js
 
 - name: remove container if exists
   docker_container:
-    name: "{{ application_name }}_datasheet"
+    name: "{{ timemap.name }}_datasheet"
     state: absent
     force_kill: true
 
 - name: remove image if exists
   docker_image:
     state: absent
-    name: "{{ application_name }}_datasheet_prod"
+    name: "{{ timemap.name }}_datasheet_prod"
     force: true
 
 - name: build docker image
   docker_image:
     path: datasheet-server
-    name: "{{ application_name }}_datasheet_prod"
+    name: "{{ timemap.name }}_datasheet_prod"
+
+- name: interpolate volume strings for XLSX
+  set_fact:
+    xlsx_volumes: "{{ datasheet.xlsx | json_query('[].name') | map('regex_replace', '(^.*$)', 'xlsx/\\1.xlsx:/\\1.xlsx') | list }}"
 
 - name: run datasheet-server in container
   docker_container:
-    name: "{{ application_name }}_datasheet"
-    image: "{{ application_name }}_datasheet_prod"
+    name: "{{ timemap.name }}_datasheet"
+    image: "{{ timemap.name }}_datasheet_prod"
+    volumes: "{{ xlsx_volumes | list }}"
     ports:
       - "0.0.0.0:{{ datasheet.port }}:8080"

--- a/deploy_timemap/tasks/datasheet.yml
+++ b/deploy_timemap/tasks/datasheet.yml
@@ -65,7 +65,7 @@
 
 - name: interpolate volume strings for XLSX
   set_fact:
-    xlsx_volumes: "{{ datasheet.xlsx | json_query('[].name') | map('regex_replace', '(^.*$)', 'xlsx/\\1.xlsx:/\\1.xlsx') | list }}"
+    xlsx_volumes: "{{ datasheet.xlsx | json_query('[].name') | map('regex_replace', '(^.*$)', ansible_env.HOME + '/xlsx/\\1.xlsx:/\\1.xlsx') | list }}"
 
 - name: run datasheet-server in container
   docker_container:

--- a/deploy_timemap/tasks/datasheet.yml
+++ b/deploy_timemap/tasks/datasheet.yml
@@ -16,61 +16,73 @@
     state: directory
 
 - name: copy .env to credentials folder
-  template: src=../templates/datasheet-env.j2 dest=credentials/{{timemap.name}}.env
+  template: src=../templates/datasheet-env.j2 dest=credentials/datasheet.env
 
 - name: copy sheets_config.js to credentials folder
   template: >
     src=../templates/datasheet_sheets_config.js.j2
-    dest=credentials/{{ timemap.name }}_sheets_config.js
+    dest=credentials/sheets_config.js
 
 - name: create XLSX folder if it does not already exist
   file:
     path: xlsx
     state: directory
+  when: datasheet.xlsx is defined
 
 - name: copy XLSX files to credentials folder
   copy:
     src: "{{ item.path }}"
     dest: xlsx/{{ item.name }}.xlsx
   loop: "{{ datasheet.xlsx }}"
+  when: datasheet.xlsx is defined
 
 - name: copy .env to datasheet folder
   copy:
     remote_src: true
-    src: credentials/{{ timemap.name }}.env
+    src: credentials/datasheet.env
     dest: datasheet-server/.env
 
 - name: copy sheets_config.js to datasheet folder
   copy:
     remote_src: true
-    src: credentials/{{ timemap.name }}_sheets_config.js
+    src: credentials/sheets_config.js
     dest: datasheet-server/src/sheets_config.js
 
 - name: remove container if exists
   docker_container:
-    name: "{{ timemap.name }}_datasheet"
+    name: datasheet
     state: absent
     force_kill: true
 
 - name: remove image if exists
   docker_image:
     state: absent
-    name: "{{ timemap.name }}_datasheet_prod"
+    name: datasheet_prod
     force: true
 
 - name: build docker image
   docker_image:
     path: datasheet-server
-    name: "{{ timemap.name }}_datasheet_prod"
+    name: datasheet_prod
 
 - name: interpolate volume strings for XLSX
   set_fact:
     xlsx_volumes: "{{ datasheet.xlsx | json_query('[].name') | map('regex_replace', '(^.*$)', ansible_env.HOME + '/xlsx/\\1.xlsx:/\\1.xlsx') | list }}"
+  when: datsheet.xlsx is defined
 
-- name: run datasheet-server in container
+- name: run datasheet-server in container with XLSX volumes
   docker_container:
-    name: "{{ timemap.name }}_datasheet"
-    image: "{{ timemap.name }}_datasheet_prod"
+    name: datasheet
+    image: datasheet_prod
     volumes: "{{ xlsx_volumes | list }}"
     ports:
       - "0.0.0.0:{{ datasheet.port }}:8080"
+  when: datasheet.xlsx is defined
+
+- name: run datasheet-server in container (w/o volumes)
+  docker_container:
+    name: datasheet
+    image: datasheet_prod
+    ports:
+      - "0.0.0.0:{{ datasheet.port }}:8080"
+  when: datasheet.xlsx is not defined

--- a/deploy_timemap/tasks/nginx.yml
+++ b/deploy_timemap/tasks/nginx.yml
@@ -20,15 +20,15 @@
 - name: add line in nginx config for server reverse proxy
   lineinfile:
     dest: /etc/nginx/sites-available/default
-    line: "\tlocation /{{ application_name }}-server {rewrite /{{ application_name }}-server/(.*) /$1 break;proxy_pass http://127.0.0.1:{{ datasheet.port }};}"
+    line: "\tlocation /{{ datasheet.name }}-server {rewrite /{{ datasheet.name }}-server/(.*) /$1 break;proxy_pass http://127.0.0.1:{{ datasheet.port }};}"
     insertafter: 'server_name {{ domain_name }} www.{{ domain_name }};'
     state: present
     create: yes
 
-- name: add line in nginx config for timemap alias for {{ application_name }} with domain name:{{ domain_name }} 
+- name: add line in nginx config for timemap alias for {{ datasheet.name }} with domain name:{{ domain_name }}
   lineinfile:
     dest: /etc/nginx/sites-available/default
-    line: "\tlocation /{{ application_name }} {root /var/www/html;}"
+    line: "\tlocation /{{ datasheet.name }} {root /var/www/html;}"
     insertafter: 'server_name {{ domain_name }} www.{{ domain_name }};'
     state: present
     create: yes

--- a/deploy_timemap/tasks/nginx.yml
+++ b/deploy_timemap/tasks/nginx.yml
@@ -20,21 +20,17 @@
 - name: add line in nginx config for server reverse proxy
   lineinfile:
     dest: /etc/nginx/sites-available/default
-    line: "\tlocation /{{ datasheet.name }}-server {rewrite /{{ datasheet.name }}-server/(.*) /$1 break;proxy_pass http://127.0.0.1:{{ datasheet.port }};}"
+    line: "\tlocation /{{ timemap.name }}-server {rewrite /{{ timemap.name }}-server/(.*) /$1 break;proxy_pass http://127.0.0.1:{{ datasheet.port }};}"
     insertafter: 'server_name {{ domain_name }} www.{{ domain_name }};'
     state: present
     create: yes
 
-- name: add line in nginx config for timemap alias for {{ datasheet.name }} with domain name:{{ domain_name }}
+- name: add line in nginx config for timemap alias for {{ timemap.name }} with domain name:{{ domain_name }}
   lineinfile:
     dest: /etc/nginx/sites-available/default
-    line: "\tlocation /{{ datasheet.name }} {root /var/www/html;}"
+    line: "\tlocation /{{ timemap.name }} {root /var/www/html;}"
     insertafter: 'server_name {{ domain_name }} www.{{ domain_name }};'
     state: present
     create: yes
 
-- name: enable config
-  file: >
-    dest=/etc/nginx/sites-enabled/default
-    src=/etc/nginx/sites-available/default
-    state=link
+

--- a/deploy_timemap/tasks/timemap.yml
+++ b/deploy_timemap/tasks/timemap.yml
@@ -1,38 +1,31 @@
-- name: ansible host - clean timemap repo state
-  local_action:
-    module: file
-    state: absent
-    path: timemap
-
 - name: create credentials folder if it does not already exist
   file:
     path: credentials
     state: directory
 
-- name: ansible host - checkout timemap repo
+- name: ansible host - clean config.js
   local_action:
-    module: git
-    repo: "{{ lookup('env', 'TIMEMAP_GIT_REPOSITORY') or 'https://github.com/forensic-architecture/timemap' }}"
-    dest: timemap
-    version: "{{ lookup('env', 'TIMEMAP_GIT_BRANCH') or 'develop' }}"
+    module: file
+    state: absent
+    path: timemap/config.js
 
-- name: copy config.js to timemap
+- name: ansible host - clean index.html
+  local_action:
+    module: file
+    state: absent
+    path: timemap/index.html
+
+- name: ansible host - copy config.js file
   local_action:
     module: template
     src: ../templates/timemap_config.js.j2
     dest: timemap/config.js
 
-- name: copy index.html to timemap
+- name: ansible host - copy index.html file
   local_action:
     module: template
     src: ../templates/index.html.j2
     dest: timemap/index.html
-
-- name: install packages on ansible host
-  local_action:
-    module: yarn
-    path: timemap
-    state: latest
 
 - name: ansible host - build app
   local_action:
@@ -61,8 +54,4 @@
     src: timemap/config.js
     dest: credentials/{{ timemap.name }}_config.js
 
-- name: ansible host - remove timemap repo
-  local_action:
-    module: file
-    state: absent
-    path: timemap
+

--- a/deploy_timemap/tasks/timemap.yml
+++ b/deploy_timemap/tasks/timemap.yml
@@ -45,7 +45,7 @@
     state: absent
     # Uncomment the next line and comment the one after if you are NOT using
     # multiple timemap instances on the same host.
-    path: '{{ static_files_folder }}/{{ application_name }}'
+    path: '{{ static_files_folder }}/{{ timemap.name }}'
     # path: '{{ static_files_folder }}'
 
 - name: copy files from timemap build to server's static files folder
@@ -53,13 +53,13 @@
     src: timemap/build/
     # Uncomment the next line and comment the one after if you are NOT using
     # multiple timemap instances on the same host.
-    dest: '{{ static_files_folder }}/{{ application_name }}'
+    dest: '{{ static_files_folder }}/{{ timemap.name }}'
     # dest: '{{ static_files_folder }}'
 
 - name: copy config.js to credentials folder
   copy:
     src: timemap/config.js
-    dest: credentials/{{ application_name }}_config.js
+    dest: credentials/{{ timemap.name }}_config.js
 
 - name: ansible host - remove timemap repo
   local_action:

--- a/deploy_timemap/templates/datasheet-env.j2
+++ b/deploy_timemap/templates/datasheet-env.j2
@@ -1,3 +1,3 @@
 PORT={{ datasheet.port }}
-SERVICE_ACCOUNT_EMAIL="{{ service_account.email }}"
-SERVICE_ACCOUNT_PRIVATE_KEY="{{ service_account.private_key }}"
+SERVICE_ACCOUNT_EMAIL="{{ datasheet.service_account.email }}"
+SERVICE_ACCOUNT_PRIVATE_KEY="{{ datasheet.service_account.private_key }}"

--- a/deploy_timemap/templates/datasheet_sheets_config.js.j2
+++ b/deploy_timemap/templates/datasheet_sheets_config.js.j2
@@ -34,7 +34,7 @@ export default {
     name: '{{ sheet.name }}',
     id: '{{ sheet.id }}',
     tabs: {{ sheet.name }}Structure
-  }
+  },
   {% endfor %}
   {% endif %}
   ],
@@ -45,7 +45,7 @@ export default {
     name: '{{ sheet.name }}',
     path: '/{{ sheet.name }}.xlsx', /* passed from local->instance->docker volume */
     tabs: {{ sheet.name }}Structure
-  }
+  },
   {% endfor %}
   {% endif %}
   ]

--- a/deploy_timemap/templates/datasheet_sheets_config.js.j2
+++ b/deploy_timemap/templates/datasheet_sheets_config.js.j2
@@ -1,18 +1,52 @@
 import BP from './lib/blueprinters'
 
-const timemapStructure = {
-  {{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.events is defined else '' }}export_events: BP.deeprows,
-  {{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.categories is defined else '' }}export_categories: [BP.groups, BP.rows],
-  {{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.narratives is defined else '' }}export_narratives: BP.rows,
-  {{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.sources is defined else '' }}export_sources: BP.deepids,
-  {{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.sites is defined else '' }}export_sites: BP.rows,
-  {{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.tags is defined else '' }}export_tags: BP.tree,
+{% if datasheet.gsheets is defined %}
+{% for sheet in datasheet.gsheets %}
+const {{ sheet.name }}Structure = {
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.events is defined else '' }}export_events: BP.deeprows,
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.categories is defined else '' }}export_categories: [BP.groups, BP.rows],
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.narratives is defined else '' }}export_narratives: BP.rows,
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.sources is defined else '' }}export_sources: BP.deepids,
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.sites is defined else '' }}export_sites: BP.rows,
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.tags is defined else '' }}export_tags: BP.tree,
 }
+{% endfor %}
+{% endif %}
+
+{% if datasheet.xlsx is defined %}
+{% for sheet in datasheet.xlsx %}
+const {{ sheet.name }}Structure = {
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.events is defined else '' }}export_events: BP.deeprows,
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.categories is defined else '' }}export_categories: [BP.groups, BP.rows],
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.narratives is defined else '' }}export_narratives: BP.rows,
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.sources is defined else '' }}export_sources: BP.deepids,
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.sites is defined else '' }}export_sites: BP.rows,
+  {{ sheet.name +'_' if sheet.prefix_sheet_tabs is defined and sheet.prefix_sheet_tabs.tags is defined else '' }}export_tags: BP.tree,
+}
+{% endfor %}
+{% endif %}
 
 export default {
-  gsheets: [{
-    name: '{{ application_name }}',
-    id: '{{ datasheet.sheet_id }}',
-    tabs: timemapStructure
-  }]
+  gsheets: [
+  {% if datasheet.gsheets is defined %}
+  {% for sheet in datasheet.gsheets %}
+  {
+    name: '{{ sheet.name }}',
+    id: '{{ sheet.id }}',
+    tabs: {{ sheet.name }}Structure
+  }
+  {% endfor %}
+  {% endif %}
+  ],
+  xlsx: [
+  {% if datasheet.xlsx is defined %}
+  {% for sheet in datasheet.xlsx %}
+  {
+    name: '{{ sheet.name }}',
+    path: '/{{ sheet.name }}.xlsx', /* passed from local->instance->docker volume */
+    tabs: {{ sheet.name }}Structure
+  }
+  {% endfor %}
+  {% endif %}
+  ]
 }

--- a/deploy_timemap/templates/index.html.j2
+++ b/deploy_timemap/templates/index.html.j2
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>{{ display_name }}</title>
+  <title>{{ timemap.display_name }}</title>
   <link rel="stylesheet" href="https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css">
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/deploy_timemap/templates/timemap_config.js.j2
+++ b/deploy_timemap/templates/timemap_config.js.j2
@@ -1,16 +1,16 @@
 module.exports = {
-  title: '{{ application_name }}',
-  display_title: '{{ display_name }}',
-  SERVER_ROOT: 'http{{ 's' if use_https else '' }}://{{ domain_name }}/{{ application_name }}-server',
-  EVENT_EXT: '/api/{{ application_name }}/{{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.events is defined else '' }}export_events/deeprows',
-  CATEGORY_EXT: '/api/{{ application_name }}/{{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.categories is defined else '' }}export_categories/rows',
-  SOURCES_EXT: '/api/{{ application_name }}/{{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.sources is defined else '' }}export_sources/deepids',
-  NARRATIVE_EXT: '/api/{{ application_name }}/{{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.narratives is defined else '' }}export_narratives/rows',
-  TAGS_EXT: '/api/{{ application_name }}/{{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.tags is defined else '' }}export_tags/tree',
-  SITES_EXT: '/api/{{ application_name }}/{{ application_name+'_' if prefix_sheet_tabs is defined and prefix_sheet_tabs.sites is defined else '' }}export_sites/rows',
-  INCOMING_DATETIME_FORMAT: '{{ datetime_format if datetime_format is defined else '%m/%d/%YT%H:%M'}}',
-{% if mapbox_token is defined %}
-  MAPBOX_TOKEN: '{{ mapbox_token }}',
+  title: '{{ timemap.name }}',
+  display_title: '{{ timemap.display_name }}',
+  SERVER_ROOT: 'http{{ 's' if use_https else '' }}://{{ domain_name }}/{{ timemap.name }}-server',
+  EVENT_EXT: '/api/{{ timemap.name }}/{{ timemap.name+'_' if timemap.prefix_sheet_tabs is defined and timemap.prefix_sheet_tabs.events is defined else '' }}export_events/deeprows',
+  CATEGORY_EXT: '/api/{{ timemap.name }}/{{ timemap.name+'_' if timemap.prefix_sheet_tabs is defined and timemap.prefix_sheet_tabs.categories is defined else '' }}export_categories/rows',
+  SOURCES_EXT: '/api/{{ timemap.name }}/{{ timemap.name+'_' if timemap.prefix_sheet_tabs is defined and timemap.prefix_sheet_tabs.sources is defined else '' }}export_sources/deepids',
+  NARRATIVE_EXT: '/api/{{ timemap.name }}/{{ timemap.name+'_' if timemap.prefix_sheet_tabs is defined and timemap.prefix_sheet_tabs.narratives is defined else '' }}export_narratives/rows',
+  TAGS_EXT: '/api/{{ timemap.name }}/{{ timemap.name+'_' if timemap.prefix_sheet_tabs is defined and timemap.prefix_sheet_tabs.tags is defined else '' }}export_tags/tree',
+  SITES_EXT: '/api/{{ timemap.name }}/{{ timemap.name+'_' if timemap.prefix_sheet_tabs is defined and timemap.prefix_sheet_tabs.sites is defined else '' }}export_sites/rows',
+  INCOMING_DATETIME_FORMAT: '{{ timemap.datetime_format if timemap.datetime_format is defined else '%m/%d/%YT%H:%M'}}',
+{% if timemap.mapbox_token is defined %}
+  MAPBOX_TOKEN: '{{ timemap.mapbox_token }}',
 {% endif %}
   features: {
 {% for key, value in timemap.features.items() %}

--- a/deploy_timemap/templates/timemap_config.js.j2
+++ b/deploy_timemap/templates/timemap_config.js.j2
@@ -33,7 +33,8 @@ module.exports = {
         rangeLimits: [
           new Date("{{ timemap.store.app.timeline.rangeLimits[0] }}"),
           new Date("{{ timemap.store.app.timeline.rangeLimits[1] }}")
-        ]
+        ],
+        dimensions: {{ (timemap.store.app.timeline.dimensions | to_nice_json) if timemap.store.app.timeline.dimensions is defined else {}}}
       }
     },
     ui: {{ timemap.store.ui | to_nice_json }}

--- a/deploy_timemap/vars/main.yml
+++ b/deploy_timemap/vars/main.yml
@@ -1,19 +1,23 @@
 domain_name: example.com
-application_name: example
-static_files_folder: /var/www/html
 use_https: false
+static_files_folder: /var/www/html
+
 datasheet:
   port: 8080
   sheet_id: 1SJ4D30c5s1lrMKU3v3cfhNZv9vdKp6_sPJQ0s2hw6R0
-timemap:
-  features:
-    USE_COVER: false
-    USE_TAGS: false
-    USE_SEARCH: false
-    USE_SITES: false
-    USE_SOURCES: false
-    CATEGORIES_AS_TAGS: true
-    NARRATIVE_STEP_STYLES: false
 
-  # NB: any custom values in the redux store can be specified here
-  # store:
+timemaps:
+  - name: example
+    display_name: Example Timemap
+    features:
+      USE_COVER: false
+      USE_TAGS: false
+      USE_SEARCH: false
+      USE_SITES: false
+      USE_SOURCES: false
+      USE_NARRATIVES: false
+      CATEGORIES_AS_TAGS: true
+      NARRATIVE_STEP_STYLES: false
+
+    # NB: any custom values in the redux store can be specified here
+    # store:


### PR DESCRIPTION
closes #2 

This changes the structure of vault.yml to be more flexible. It now enables a vault to have more than one Datasheet Server, either sourced from a Google Sheet (`gsheets`) or a local XLSX file (which is copied over to the server when the playbook is run).

It also allows the deployment of multiple timemaps from a single vault, all connected to the same  datasheet-server (with optionally prefixed routes for events, sources, categories, etc). 