### PR TITLE
Create example.vault.yml 

### DIFF
--- a/deploy_timemap/vars/example.vault.yml
+++ b/deploy_timemap/vars/example.vault.yml
@@ -1,0 +1,36 @@
+service_account:
+  email: service_account@account_name.iam.gserviceaccount.com
+  private_key: -----BEGIN PRIVATE YOUR_PRIVATE_KEY_HERE PRIVATE KEY-----\n
+domain_name: 'your-domain-name.com'
+application_name: 'forensic'
+display_title: 'Your Title'
+use_https: false
+display_name: 'Your Display Name'
+mapbox_token: your_mapbox_token
+datasheet:
+  port: 4040
+  sheet_id: 'your-google-sheet-id'
+timemap:
+  features:
+    USE_COVER: true
+    USE_TAGS: true
+    USE_SEARCH: true
+    USE_SITES: true
+    USE_SOURCES: true
+    CATEGORIES_AS_TAGS: true
+    # ...any features
+  store:
+    # ...any custom store values
+  ui:
+      # tiles: 'your-mapbox-map-id-'
+      style:
+        categories:
+          'your-category-label': 'your-colour'
+        narratives: 
+          default: 
+            stroke: 'none'
+        shapes: 
+          default: 
+            stroke: 'blue'
+            strokeWidth: 3
+            opacity: 0.9


### PR DESCRIPTION
From README: 

> Copy example.vault.yml to a new vault.yml in the same folder. The vault file contains all Timemap/Datasheet specific configuration. See the Timemap and Datasheet-Server](https://github.com/forensic-architecture/datasheet-server) documentation for more infomation. All files that end in 'vault.yml' are ignored from git, so you can keep configuration for multiple applications inside this folder locally, and symlink to 'vault.yml' when deploying one.

But no example.yault.yml in /vars/ or elsewhere in current repository ([found here](https://github.com/forensic-architecture/devops/blob/3194603e1efab92676ff7273e16dfce323a98587/timemap_datasheet/vars/example.vault.yml)). 

