### PR TITLE
Update aws-timemap.tf

### DIFF
--- a/provision/aws-instance/aws-timemap.tf
+++ b/provision/aws-instance/aws-timemap.tf
@@ -5,11 +5,10 @@ provider "aws" {
 
 resource "aws_s3_bucket" "timemap-bucket" {
   bucket = var.bucket-name
-  region = var.region
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["GET"]
-    allowed_origins = [vars.cors_allowed_origins]
+    allowed_origins = [var.cors_allowed_origins]
     max_age_seconds = 3000
   }
 


### PR DESCRIPTION
vars.cors_allowed_origins should be var.cors_allowed_origins
aws_s3_bucket - region attribute has depreciated and no longer configureable, needs removing (see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_s3_bucket)